### PR TITLE
Release/1.2.7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cmake"]
 	path = cmake
-	url = git://github.com/jrl-umi3218/jrl-cmakemodules.git
+	url = https://github.com/jrl-umi3218/jrl-cmakemodules.git

--- a/sot_application/acceleration/precomputed_meta_tasks.py
+++ b/sot_application/acceleration/precomputed_meta_tasks.py
@@ -13,6 +13,7 @@ from dynamic_graph.sot.dyninv.meta_tasks_dyn import MetaTaskDynCom, MetaTaskDynP
 
 
 class Solver:
+
     def __init__(self, robot):
         self.robot = robot
         """

--- a/sot_application/velocity/precomputed_meta_tasks.py
+++ b/sot_application/velocity/precomputed_meta_tasks.py
@@ -15,6 +15,7 @@ from dynamic_graph.sot.dyninv import SolverKine, TaskInequality, TaskJointLimits
 
 
 class Solver:
+
     def __init__(self, robot):
         self.robot = robot
 

--- a/sot_application/velocity/precomputed_tasks.py
+++ b/sot_application/velocity/precomputed_tasks.py
@@ -16,6 +16,7 @@ from dynamic_graph.sot.core.sot import SOT, Task
 
 
 class Solver:
+
     def __init__(self, robot, solverType=SOT):
         self.robot = robot
 
@@ -206,6 +207,7 @@ class Application(object):
       - comdot: input (vector) reference velocity of the center of mass
 
     """
+
     def __init__(self, robot, solverType=SOT):
 
         self.robot = robot


### PR DESCRIPTION
to fix CI because:
```
Submodule 'cmake' (git://github.com/jrl-umi3218/jrl-cmakemodules.git) registered for path 'cmake'
Cloning into '/root/robotpkg/wip/py-sot-application-v3/work/sot-application-1.2.6/cmake'...
fatal: remote error:
The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
fatal: clone of 'git://github.com/jrl-umi3218/jrl-cmakemodules.git' into submodule path '/root/robotpkg/wip/py-sot-application-v3/work/sot-application-1.2.6/cmake' failed
```

This was already fixed in #10